### PR TITLE
Readme unified and check project against 23.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ https://user-images.githubusercontent.com/87207603/235952495-29eacd36-fbbf-4fcc-
 
 ![SplashScreen](https://user-images.githubusercontent.com/87207603/235951250-4684e278-e83d-462c-95ab-ce1d51d2026d.jpg)
 
-![screeshot](screenshot-1.png?raw=true)
-
 ## License
 
 For terms please see the LICENSE\*.TXT files at the root of this repository.

--- a/README.md
+++ b/README.md
@@ -1,188 +1,52 @@
-# Protect-the-Moon
+<u>Supported o3de versions</u> : **23.10**
 
-Project Or Game Description:
+# Protect the Moon
+
+![full_screen](https://user-images.githubusercontent.com/87207603/235952195-ed90adac-f32a-4226-aa6f-5bc1ebede266.gif)
+
 Protect the Moon is a retro-style game that features classic arcade gameplay. As the defender of one of the most essential and precious
 assets of our planet - the Moon, you must protect it at all costs against alien invaders who have taken control of it. 
 
-**This game is just one example of the many games included in the O3DE learning series 
-available at the following link: https://youtube.com/playlist?list=PLCQwFpnHSZQgyIu4JeOUDCsNCVgWOz3Mf**
+**You can learn to make this project from scratch by [following this youtube playlist](https://www.youtube.com/playlist?list=PLCQwFpnHSZQgyIu4JeOUDCsNCVgWOz3Mf)**
 
-![SplashScreen](https://user-images.githubusercontent.com/87207603/235951250-4684e278-e83d-462c-95ab-ce1d51d2026d.jpg)
+## Prerequisites
 
-## The Project Includes
+You need to build or [install O3DE engine](https://o3de.org/download/).
+
+## How to run
+
+1. Download (green "Code" button, then "Download ZIP") or clone the github repository (`git clone https://github.com/o3de/Protect-the-Moon.git`)
+2. Launch O3DE. It will open the Project manager. Click on the **New Project** button then **Open Existing Project** option.
+3. Navigate to your download (and make sure it is unzipped). Open this folder. The project should now be registered.
+
+<img width="162" alt="build" src="https://user-images.githubusercontent.com/87207603/235956071-9c1a20f0-052e-4e06-8fa1-afe8073d1c42.png">
+
+4. Click on the **Build Project** button, located on the **Protect-the-Moon** image.
+5. Once the project has been built sucessfully, use the **Open Editor** button.
+6. The asset pre-processor will run for a bit. Once it is over you will be welcomed with the **Open a Level** window, simply pick the first one.
+
+## Controls
+
+The player can be moved around the level using the A and D commands and Left Mouse Clicks will fire your weapon.  
+
+## Project Highlights
+
+https://user-images.githubusercontent.com/87207603/235952495-29eacd36-fbbf-4fcc-8e86-c816cafcad7c.mp4
 
 - **Project Setup** Introduction to game development, setup of development environment and introduction to the game concept.
-- **A Creating The Main Menu** Here we create a simple menu that launches the first level of the game.
+- **Main Menu** Here we create a simple menu that launches the first level of the game.
 - **Enemies & Spawning Assets Prefabs** Importing the player and enemy ships.
 - **Player Movement** Implementing player movement.
 - **Projectiles & Collision** Implementing enemy movement and Projectiles.
 - **In Game HUD - Scoring and Lives** Setting Up the In Game HUD UI Canvas and Script Canvas.
-- **Game Assets Prefabs** The of the Alien Enemies, Projectiles, and the Main Player Character.
+- **Game Assets Prefabs** Alien Enemies, Projectiles, and the Main Player Character.
 
-## Protect the Moon Tutorial Video Series![Protect_the_Moon_01](https://user-images.githubusercontent.com/87207603/235951941-332c2166-11d3-4b6b-acc0-ef62ec3e7912.png)
-## In Editor Game Shots!
-![in_editor_shot](https://user-images.githubusercontent.com/87207603/235952125-1ab1c72d-a571-4db4-b4b5-db523526af0e.gif)
-## Full Screen Game Play!
-![full_screen](https://user-images.githubusercontent.com/87207603/235952195-ed90adac-f32a-4226-aa6f-5bc1ebede266.gif)
-## GAME PLAY VIDEO
-https://user-images.githubusercontent.com/87207603/235952495-29eacd36-fbbf-4fcc-8e86-c816cafcad7c.mp4
+### Screenshots
 
-## Game Levels
+![SplashScreen](https://user-images.githubusercontent.com/87207603/235951250-4684e278-e83d-462c-95ab-ce1d51d2026d.jpg)
 
-- **Level_01** is the main game play level for a full game loop.
+![screeshot](screenshot-1.png?raw=true)
 
-## Requirements
-
-### Platforms
-
-The project supports the following platforms:
-
-- **Windows 10 version 1809 (10.0.17763)** or later is required.
-
-## O3DE Installation
-
-1. Refer to the [O3DE System Requirements](https://www.o3de.org/docs/welcome-guide/requirements/) documentation to make sure that the system/hardware requirements are met.
-2. Please follow the instructions to [set up O3DE from GitHub](https://o3de.org/docs/welcome-guide/setup/setup-from-github/).
-3. **Use the development branch**: git checkout development.
-
-# Building the project
-
-## Build Steps
-
-1. Clone the **Protect-the-Moon** game project from the following repo:
-2. git clone https://github.com/o3de/Protect-the-Moon
-3. Within the Project manager locate and click on the **New Project** button. Then from the drop down menu select the **Open Existing Project** option.
-4. Once Windows Explorer opens, navigate to and select the **Protect-the-Moon** folder. Once selected click on the **Select Folder** button.
-5. This will load the **Protect-the-Moon** project into the **Project Manager**.
-
-<img width="162" alt="build" src="https://user-images.githubusercontent.com/87207603/235956071-9c1a20f0-052e-4e06-8fa1-afe8073d1c42.png">
-
-
-1. In order to build the project, locate and click on the **Build Project** button, located on the **Protect-the-Moon** icon.
-
-## Launching the Project
-
-1. Once the project has been built successfully, the **Build Project** button will disappear and an **Open Editor** button should be the only option you can select.
-2. Click on the **Open Editor** button this will open the **Protect-the-Moon** project.
-
-## Opening the Game-play Level
-
-1. Once the Asset Processor has completed importing and processing a significance portion of the assets the O3DE Editor will open.
-2. In the **Welcome to O3DE** splash screen select the **Open** button to open a new level.
-3. This will open the **Open a Level** window
-4. Select the **Level_01** level and click the open level to launch the level.
-5. Once the level opens, the menu splash screen will ask you to mouse click to start the game.
-
-**Controlling the Main Player**
-
-**Navigation**
-
-1. The Main Player model can be moved around the level using the A and D commands and Left Mouse Clicks will fire your weapon.  
-
-**License**
+## License
 
 For terms please see the LICENSE\*.TXT files at the root of this repository.
-
-For the sake of clarification licensing information can be also be found below.
-
-| OPEN 3D ENGINE LICENSING |
-| ------------------------ |
-|                          |
-
-| The default license for Open 3D Engine is the Apache License, Version 2.0 |
-| ------------------------------------------------------------------------- |
-|                                                                           |
-
-| (see LICENSE_APACHE2.TXT); you may elect at your option to use the Open 3D |
-| -------------------------------------------------------------------------- |
-|                                                                            |
-
-| Engine under the MIT License (see LICENSE_MIT.TXT). Contributions must be |
-| ------------------------------------------------------------------------- |
-|                                                                           |
-
-| made under both licenses. |
-| ------------------------- |
-|                           |
-
-|     |
-| --- |
-|     |
-
-| THIRD PARTY COMPONENTS |
-| ---------------------- |
-|                        |
-
-| Open 3D Engine requires the use of (and in some cases makes available to you) |
-| ----------------------------------------------------------------------------- |
-|                                                                               |
-
-| software and assets that have been developed by third parties and are subject |
-| ----------------------------------------------------------------------------- |
-|                                                                               |
-
-| to separate license terms (such as code licensed under other open source |
-| ------------------------------------------------------------------------ |
-|                                                                          |
-
-| licenses). It is your responsibility to comply with the applicable licenses. |
-| ---------------------------------------------------------------------------- |
-|                                                                              |
-
-| Information on third party materials, and the applicable license terms, are |
-| --------------------------------------------------------------------------- |
-|                                                                             |
-
-| referenced in or included with the materials, such as in separate LICENSE.txt |
-| ----------------------------------------------------------------------------- |
-|                                                                               |
-
-| files accompanying the materials. |
-| --------------------------------- |
-|                                   |
-
-|     |
-| --- |
-|     |
-
-| Please note that certain materials are subject to "copyleft" licenses, which |
-| ---------------------------------------------------------------------------- |
-|                                                                              |
-
-| require distribution of source code, including: |
-| ----------------------------------------------- |
-|                                                 |
-
-|     |
-| --- |
-|     |
-
-| - Qt Toolkit https://github.com/qtproject/, which is subject to the GNU |
-| ----------------------------------------------------------------------- |
-|                                                                         |
-
-| Lesser General Public License version 3 (with certain exceptions). A copy of |
-| ---------------------------------------------------------------------------- |
-|                                                                              |
-
-| the source code for Qt Toolkit may be found at |
-| ---------------------------------------------- |
-|                                                |
-
-| https://s3-us-west-2.amazonaws.com/ly-legal/LicenseConformance/Qt/Src.zip |
-| ------------------------------------------------------------------------- |
-|                                                                           |
-
-|     |
-| --- |
-|     |
-
-| - The AWS Python SDK uses Chardet https://chardet.github.io/, which is |
-| ---------------------------------------------------------------------- |
-|                                                                        |
-
-| subject to the GNU Lesser General Public License version 2.1. A copy of the |
-| --------------------------------------------------------------------------- |
-|                                                                             |
-
-source code may be found at https://github.com/chardet/chardet.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ assets of our planet - the Moon, you must protect it at all costs against alien 
 
 You need to build or [install O3DE engine](https://o3de.org/download/).
 
+You need to [install git with lfs support](https://git-scm.com/downloads), and [setup a token on your github account](https://www.docs.o3de.org/docs/welcome-guide/setup/setup-from-github/#configure-credentials-for-git-lfs). Needed as the repository uses Git LFS, the "Download ZIP" button will not download assets.
+
 ## How to run
 
-1. Download (green "Code" button, then "Download ZIP") or clone the github repository (`git clone https://github.com/o3de/Protect-the-Moon.git`)
+1. Clone the github repository (`git clone https://github.com/o3de/Protect-the-Moon.git`). When prompted to authenticate, use your github username and the token as password.
 2. Launch O3DE. It will open the Project manager. Click on the **New Project** button then **Open Existing Project** option.
-3. Navigate to your download (and make sure it is unzipped). Open this folder. The project should now be registered.
+3. Navigate to the cloned repository. Open this folder. The project should now be registered.
 
 <img width="162" alt="build" src="https://user-images.githubusercontent.com/87207603/235956071-9c1a20f0-052e-4e06-8fa1-afe8073d1c42.png">
 
 4. Click on the **Build Project** button, located on the **Protect-the-Moon** image.
-5. Once the project has been built sucessfully, use the **Open Editor** button.
+5. Once the project has been built successfully, use the **Open Editor** button.
 6. The asset pre-processor will run for a bit. Once it is over you will be welcomed with the **Open a Level** window, simply pick the first one.
 
 ## Controls

--- a/project.json.bak1
+++ b/project.json.bak1
@@ -44,5 +44,5 @@
         "WhiteBox",
         "LyShineExamples"
     ],
-    "engine_version": "2.2.2"
+    "engine_version": "2.0.0"
 }


### PR DESCRIPTION
First take on an unified readme format used accross every O3DE samples (and checked that the project still runs correctly on the release of 23.10.3)

The goal being to make the samples more accessible to the users. Both by updating the project's readme, adding a version check and linking them in O3DE showcase and doc pages. Task tracked via this issue : https://github.com/o3de/o3de.org/issues/2549

Note : I wasn't able to update an additional screenhot because of git lfs, weird as I followed [those steps properly](https://www.docs.o3de.org/docs/welcome-guide/setup/setup-from-github/)